### PR TITLE
add: Enabling mount points to be passed from props

### DIFF
--- a/src/components/CacheComponent/index.tsx
+++ b/src/components/CacheComponent/index.tsx
@@ -11,10 +11,19 @@ interface Props {
     }>
     children: ReactNode
     destroy: (name: string) => void
+    cacheDivClassName?: string
 }
 
 function CacheComponent(props: Props) {
-    const { containerDivRef, active, children, destroy, name, errorElement: ErrorBoundary = Fragment } = props
+    const {
+        containerDivRef,
+        active,
+        children,
+        destroy,
+        name,
+        errorElement: ErrorBoundary = Fragment,
+        cacheDivClassName = `cache-component`,
+    } = props
     const activatedRef = useRef(false)
 
     activatedRef.current = activatedRef.current || active
@@ -23,7 +32,7 @@ function CacheComponent(props: Props) {
         const cacheDiv = document.createElement("div")
         cacheDiv.setAttribute("data-name", name)
         cacheDiv.setAttribute("style", "height: 100%")
-        cacheDiv.className = `cache-component`
+        cacheDiv.className = cacheDivClassName
         return cacheDiv
     }, [])
 

--- a/src/components/KeepAlive/index.tsx
+++ b/src/components/KeepAlive/index.tsx
@@ -94,6 +94,14 @@ interface Props {
      * ```
      */
     onBeforeActive?: (name: string) => void
+    /**
+     *  containerDivRef: root node to mount cacheNodes
+     */
+    containerDivRef?: MutableRefObject<HTMLDivElement>
+    /**
+     *  cacheDivClassName: className set for cacheNodes
+     */
+    cacheDivClassName?: string
 }
 
 interface CacheNode {
@@ -150,8 +158,10 @@ function KeepAlive(props: Props) {
         suspenseElement: SuspenseElement = Fragment,
         animationWrapper: AnimationWrapper = Fragment,
         onBeforeActive,
+        containerDivRef: containerDivRefFromoProps,
+        cacheDivClassName,
     } = props
-    const containerDivRef = useRef<HTMLDivElement>(null)
+    const containerDivRef = containerDivRefFromoProps || useRef<HTMLDivElement>(null)
     const [cacheNodes, setCacheNodes] = useState<Array<CacheNode>>([])
 
     useLayoutEffect(() => {
@@ -263,6 +273,7 @@ function KeepAlive(props: Props) {
                             active={activeName === name}
                             name={name}
                             destroy={destroy}
+                            cacheDivClassName={cacheDivClassName}
                         >
                             {ele}
                         </CacheComponent>


### PR DESCRIPTION
Hi, I wanted to use this repository as a migration from React-router v5, but the two-level deep DOM hierarchy of cached nodes made it difficult to achieve ideal styling of the nodes.

This problem was solved by allowing refs to be passed in props.

I also thought it would be better to be able to give cached nodes their own class name, so i did so.