### PR TITLE
refactor: Allow cache deletion to be handled

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ interface Props {
 type KeepAliveRef = {
   getCaches: () => Array<CacheNode>
 
-  removeCache: (name: string) => void
+  removeCache: (name: string) => Promise<void>
 
   cleanAllCache: () => void
 

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -190,7 +190,7 @@ interface Props {
 type KeepAliveRef = {
   getCaches: () => Array<CacheNode>
 
-  removeCache: (name: string) => void
+  removeCache: (name: string) => Promise<void>
 
   cleanAllCache: () => void
 

--- a/src/components/KeepAlive/index.tsx
+++ b/src/components/KeepAlive/index.tsx
@@ -127,7 +127,7 @@ const RemoveStrategies: Record<string, (nodes: CacheNode[]) => CacheNode[]> = {
 export type KeepAliveRef = {
     getCaches: () => Array<CacheNode>
 
-    removeCache: (name: string) => void
+    removeCache: (name: string) => Promise<void>
 
     cleanAllCache: () => void
 
@@ -219,12 +219,15 @@ function KeepAlive(props: Props) {
         aliveRef,
         () => ({
             getCaches: () => cacheNodes,
-            removeCache: (name: string) => {
-                setTimeout(() => {
-                    setCacheNodes(cacheNodes => {
-                        return [...cacheNodes.filter(item => item.name !== name)]
-                    })
-                }, 0)
+            removeCache: async (name: string) => {
+                return new Promise(resolve => {
+                    setTimeout(() => {
+                        setCacheNodes(cacheNodes => {
+                            return [...cacheNodes.filter(item => item.name !== name)]
+                        })
+                        resolve()
+                    }, 0)
+                })
             },
             cleanAllCache: () => {
                 setCacheNodes([])


### PR DESCRIPTION
In situations where we wanted to delete the cache and then transition to a new page, 
I faced the problem that the page to be transitioned to would be blank if the cache was asynchronously removed.
```js
  const navigate = useNavigate()
  const onClickLogo = useCallback(async (e: React.MouseEvent) => {
    e.preventDefault()
    // If the await is removed, a blank component is displayed.
    await aliveRef.current?.removeCache('/') 
    navigate('/')
  }, [navigate, aliveRef])
```
I created a PR because i think some users may face similar problems.
