### PR TITLE
fix: 解决多次渲染,内容不更新问题

### DIFF
--- a/src/components/CacheComponent/index.tsx
+++ b/src/components/CacheComponent/index.tsx
@@ -110,7 +110,11 @@ const CacheComponent = memo(
         return activatedRef.current ? createPortal(<ErrorBoundary>{children}</ErrorBoundary>, cacheDiv, cacheKey) : null;
     },
     (prevProps, nextProps) => {
-        return prevProps.active === nextProps.active && prevProps.renderCount === nextProps.renderCount;
+        return (
+            prevProps.active === nextProps.active &&
+            prevProps.renderCount === nextProps.renderCount &&
+            prevProps.children === nextProps.children
+        );
     },
 );
 

--- a/src/components/KeepAlive/index.tsx
+++ b/src/components/KeepAlive/index.tsx
@@ -173,7 +173,7 @@ function KeepAlive(props: KeepAliveProps) {
                 }
             });
         });
-    }, [activeCacheKey]);
+    }, [activeCacheKey, children]);
 
     const refresh = useCallback(
         (cacheKey?: string) => {


### PR DESCRIPTION
KeepAlive 组件 activeCacheKey 不变，但是 children 发生变化时，目前不会更新。

个人觉得当前激活态的内容是需要可以更新，辛苦看一下